### PR TITLE
fix: block unsafe state keys

### DIFF
--- a/docs/TESTING_POLICY.md
+++ b/docs/TESTING_POLICY.md
@@ -8,6 +8,10 @@
 4. Documentation/contract checks (`scripts/ci/check-docs.mjs`)
 5. Post-deploy Pages smoke (`scripts/ci/smoke-pages.mjs`)
 
+State-management security regressions are covered by source-level contract tests
+that require prototype-polluting key segments to stay blocked before dynamic
+state writes.
+
 ## Flake Handling
 
 - Keep deterministic tests in canonical verify commands.

--- a/js/core/state.js
+++ b/js/core/state.js
@@ -3,6 +3,21 @@
 import { eventBus } from './eventbus.js';
 import { BET_AMOUNT, TABS } from '../utils/constants.js';
 
+const BLOCKED_STATE_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
+
+function parseStatePath(key) {
+    if (typeof key !== 'string' || key.trim() === '') {
+        throw new TypeError('State key must be a non-empty string');
+    }
+
+    const keys = key.split('.');
+    if (keys.some((part) => part === '' || BLOCKED_STATE_KEYS.has(part))) {
+        throw new TypeError('Unsafe state key');
+    }
+
+    return keys;
+}
+
 class State {
     constructor() {
         this.data = {
@@ -28,8 +43,8 @@ class State {
     }
 
     get(key) {
-        if (key.includes('.')) {
-            const keys = key.split('.');
+        const keys = parseStatePath(key);
+        if (keys.length > 1) {
             let value = this.data;
             for (const k of keys) {
                 value = value[k];
@@ -41,11 +56,14 @@ class State {
     }
 
     set(key, value) {
-        if (key.includes('.')) {
-            const keys = key.split('.');
+        const keys = parseStatePath(key);
+        if (keys.length > 1) {
             let obj = this.data;
             for (let i = 0; i < keys.length - 1; i++) {
                 obj = obj[keys[i]];
+                if (obj === undefined || obj === null) {
+                    throw new TypeError('State path does not exist');
+                }
             }
             obj[keys[keys.length - 1]] = value;
         } else {

--- a/tests/regression/state-key-contract.test.mjs
+++ b/tests/regression/state-key-contract.test.mjs
@@ -1,0 +1,23 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const stateSource = readFileSync('js/core/state.js', 'utf8');
+
+test('state paths block prototype-polluting key segments', () => {
+  assert.match(
+    stateSource,
+    /const BLOCKED_STATE_KEYS = new Set\(\['__proto__', 'constructor', 'prototype'\]\)/,
+    'Expected state paths to reject prototype-polluting segments.',
+  );
+  assert.match(stateSource, /BLOCKED_STATE_KEYS\.has\(part\)/);
+});
+
+test('state setters reject missing nested paths before assignment', () => {
+  assert.match(
+    stateSource,
+    /obj === undefined \|\| obj === null/,
+    'Expected nested writes to fail before assigning into a missing path.',
+  );
+  assert.match(stateSource, /throw new TypeError\('State path does not exist'\)/);
+});


### PR DESCRIPTION
## What

- Adds validation for state path keys before nested reads and writes.
- Blocks prototype-polluting segments such as `__proto__`, `constructor`, and `prototype`.
- Adds a regression contract test and documents the state-management security coverage.

## Why

CodeQL surfaced a medium prototype-pollution alert in the dynamic state setter.

## How

- Centralized state path parsing in `parseStatePath`.
- Reused the parser from `get` and `set` so unsafe key segments are rejected consistently.
- Added a guard before nested writes continue through missing state paths.

## Checklist

- [x] Tests pass
- [x] No new warnings
- [x] Documentation updated (if applicable)

Validation: `bash .codex/scripts/run_verify_commands.sh`.