### PR TITLE
fix: use explicit state setters

### DIFF
--- a/docs/TESTING_POLICY.md
+++ b/docs/TESTING_POLICY.md
@@ -11,6 +11,8 @@
 State-management security regressions are covered by source-level contract tests
 that require prototype-polluting key segments to stay blocked before dynamic
 state writes.
+Writable state paths are also kept on an explicit setter allowlist so new nested
+state writes must be intentional and covered by the regression contract.
 
 ## Flake Handling
 

--- a/js/core/state.js
+++ b/js/core/state.js
@@ -4,6 +4,24 @@ import { eventBus } from './eventbus.js';
 import { BET_AMOUNT, TABS } from '../utils/constants.js';
 
 const BLOCKED_STATE_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
+const STATE_SETTERS = new Map([
+    ['currentBalance', (data, value) => { data.currentBalance = value; }],
+    ['betAmount', (data, value) => { data.betAmount = value; }],
+    ['activeTab', (data, value) => { data.activeTab = value; }],
+    ['timer', (data, value) => { data.timer = value; }],
+    ['timer.isRunning', (data, value) => { data.timer.isRunning = value; }],
+    ['timer.isPaused', (data, value) => { data.timer.isPaused = value; }],
+    ['timer.startTime', (data, value) => { data.timer.startTime = value; }],
+    ['timer.duration', (data, value) => { data.timer.duration = value; }],
+    ['timer.multiplier', (data, value) => { data.timer.multiplier = value; }],
+    ['timer.elapsedSeconds', (data, value) => { data.timer.elapsedSeconds = value; }],
+    ['timer.pausedAtSeconds', (data, value) => { data.timer.pausedAtSeconds = value; }],
+    ['events', (data, value) => { data.events = value; }],
+    ['history', (data, value) => { data.history = value; }],
+    ['history.sessions', (data, value) => { data.history.sessions = value; }],
+    ['history.bets', (data, value) => { data.history.bets = value; }],
+    ['user', (data, value) => { data.user = value; }],
+]);
 
 function parseStatePath(key) {
     if (typeof key !== 'string' || key.trim() === '') {
@@ -56,20 +74,13 @@ class State {
     }
 
     set(key, value) {
-        const keys = parseStatePath(key);
-        if (keys.length > 1) {
-            let obj = this.data;
-            for (let i = 0; i < keys.length - 1; i++) {
-                obj = obj[keys[i]];
-                if (obj === undefined || obj === null) {
-                    throw new TypeError('State path does not exist');
-                }
-            }
-            obj[keys[keys.length - 1]] = value;
-        } else {
-            this.data[key] = value;
+        const statePath = parseStatePath(key).join('.');
+        const setter = STATE_SETTERS.get(statePath);
+        if (!setter) {
+            throw new TypeError('State path is not writable');
         }
 
+        setter(this.data, value);
         eventBus.emit('state:changed', { key, value });
     }
 

--- a/tests/regression/state-key-contract.test.mjs
+++ b/tests/regression/state-key-contract.test.mjs
@@ -16,8 +16,13 @@ test('state paths block prototype-polluting key segments', () => {
 test('state setters reject missing nested paths before assignment', () => {
   assert.match(
     stateSource,
-    /obj === undefined \|\| obj === null/,
-    'Expected nested writes to fail before assigning into a missing path.',
+    /const STATE_SETTERS = new Map/,
+    'Expected writable state paths to be allowlisted.',
   );
-  assert.match(stateSource, /throw new TypeError\('State path does not exist'\)/);
+  assert.match(stateSource, /\['timer\.duration', \(data, value\) => \{ data\.timer\.duration = value; \}\]/);
+  assert.doesNotMatch(
+    stateSource,
+    /obj\[keys\[keys\.length - 1\]\] = value/,
+    'Expected state writes to avoid recursively assigning through dynamic property chains.',
+  );
 });


### PR DESCRIPTION
## What

- Replaces dynamic nested state assignment with explicit allowlisted setter functions.
- Keeps prototype-polluting state keys blocked before path lookup.
- Updates the regression contract test to require allowlisted state writes.

## Why

The initial state-key guard was safe, but CodeQL still flagged the recursive dynamic assignment pattern on `main`.

## How

- Adds a `STATE_SETTERS` map for each writable state path used by the app.
- Rejects unknown state paths before emitting state-change events.
- Removes the dynamic `obj[...] = value` write path entirely.

## Checklist

- [x] Tests pass
- [x] No new warnings
- [x] Documentation updated (if applicable)

Validation: `bash .codex/scripts/run_verify_commands.sh`.