### PR TITLE
test: allow pages action version bumps

### DIFF
--- a/tests/regression/theme-pages-contract.test.mjs
+++ b/tests/regression/theme-pages-contract.test.mjs
@@ -25,9 +25,9 @@ test('Manifest uses relative scope for GitHub Pages project deploys', () => {
 });
 
 test('Deploy workflow uses official Pages actions and post-deploy smoke', () => {
-  assert.match(workflowSource, /actions\/configure-pages@v5/);
-  assert.match(workflowSource, /actions\/upload-pages-artifact@v4/);
-  assert.match(workflowSource, /actions\/deploy-pages@v4/);
+  assert.match(workflowSource, /actions\/configure-pages@v\d+/);
+  assert.match(workflowSource, /actions\/upload-pages-artifact@v\d+/);
+  assert.match(workflowSource, /actions\/deploy-pages@v\d+/);
   assert.match(workflowSource, /scripts\/ci\/smoke-pages\.mjs/);
 });
 


### PR DESCRIPTION
## Summary
- loosen the Pages workflow contract test so it validates official action usage without pinning old major versions
- unblock Dependabot GitHub Actions version-bump PRs that intentionally change those versions

## Verification
- bash .codex/scripts/run_verify_commands.sh
- ruby YAML parse for .github/workflows/*.yml
- git diff --check